### PR TITLE
release: v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,85 @@
 All notable changes to this project will be documented in this file.  
 This project follows [Semantic Versioning](https://semver.org/) and loosely follows the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format.
 
+## [0.3.0] – 2026-03-18
+
+### Added
+
+- **`jcds.charts` module**
+  New visualization module with cleaner API (`jvis`):
+  - `missing_data_heatmap()` — heatmap of missing values across the DataFrame
+  - `outlier_boxplots()` — boxplots for numeric (non-binary) columns
+  - `correlation_heatmap()` — heatmap of feature correlations
+  - `categorical_barplot()` — bar chart for categorical variable distributions
+
+- **`jcds.transform` module**
+  New transformation module with cleaner API (`jtrf`):
+  - `to_int()`, `to_float()`, `to_numeric()`, `to_str()`
+  - `to_categorical()`, `to_bool()`, `to_datetime()`, `to_object()`
+  - `clean_column_names()`, `rename_column()`, `delete_columns()`
+
+- **`eda` module additions**
+  - `show_null_rows()` — returns rows containing at least one null value
+  - `show_null_cols()` — returns columns containing at least one null value
+
+### Changed
+
+- **`show_columns` default changed to `True`**
+  `data_info()`, `data_cardinality()`, and `data_quality()` now show column lists by default.
+
+- **`jcds.help()` updated**
+  Now includes `reports`, `transform`, and `charts` modules in function listing.
+
+- **`clean_column_names()` collision handling**
+  Now appends numeric suffix (e.g., `first_name_1`) when two columns clean to the same name.
+
+### Fixed
+
+- **`show_convar()` now excludes datetime columns**
+  Previously, datetime columns were incorrectly counted as numerical variables.
+
+- **`show_mixed_type_columns()` now ignores NaN**
+  Previously, columns with NaN values were incorrectly flagged as mixed type.
+
+- **`show_mixed_type_columns()` treats `str` and `numpy.str_` as the same type**
+  Prevents false positives after `to_str()` conversion.
+
+- **`show_possible_datetime_columns()` FutureWarning suppressed**
+  Added `utc=True` to `pd.to_datetime()` call to suppress pandas FutureWarning.
+
+### Deprecated
+
+The following `eda` functions are deprecated and will be removed in v0.4.0.
+Use the `jcds.charts` equivalents instead:
+
+- `eda.plot_outlier_boxplots()` → `charts.outlier_boxplots()`
+- `eda.plot_correlation_heatmap()` → `charts.correlation_heatmap()`
+- `eda.plot_categorical()` → `charts.categorical_barplot()`
+
+The following `eda.transform` functions are deprecated and will be removed in v0.4.0.
+Use the `jcds.transform` equivalents instead:
+
+- `eda.convert_to_int()` → `transform.to_int()`
+- `eda.convert_to_float()` → `transform.to_float()`
+- `eda.convert_to_numeric()` → `transform.to_numeric()`
+- `eda.convert_to_categorical()` → `transform.to_categorical()`
+- `eda.convert_to_bool()` → `transform.to_bool()`
+- `eda.convert_to_datetime()` → `transform.to_datetime()`
+- `eda.convert_to_object()` → `transform.to_object()`
+- `eda.clean_column_names()` → `transform.clean_column_names()`
+- `eda.rename_column()` → `transform.rename_column()`
+- `eda.delete_columns()` → `transform.delete_columns()`
+
+### Documentation
+
+- **README updated**
+  Added notebook auto-install snippet with `develop`/stable branch switching logic.
+
+### Testing
+
+- **Test suite expanded from 87 to 120 tests**
+  Added coverage for all new `charts`, `transform`, and `eda` additions.
+  
 ## [0.2.8] – 2025‑05‑02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -60,26 +60,32 @@ import importlib
 import subprocess
 import sys
 
-# Check if jcds is installed; install from GitHub if not
 package_name = "jcds"
+branch = "main"  # change to "develop" for latest dev version
 
-if importlib.util.find_spec(package_name) is None:
+if branch == "develop":
+    print(f"Installing latest '{package_name}' from '{branch}' branch...")
+    subprocess.check_call([
+        sys.executable, "-m", "pip", "install",
+        "--upgrade", "--force-reinstall",
+        f"git+https://github.com/junclemente/jcds.git@{branch}",
+    ])
+elif importlib.util.find_spec(package_name) is None:
     print(f"'{package_name}' not found. Installing from GitHub...")
-    subprocess.check_call(
-        [
-            sys.executable,
-            "-m",
-            "pip",
-            "install",
-            "git+https://github.com/junclemente/jcds.git",
-        ]
-    )
+    subprocess.check_call([
+        sys.executable, "-m", "pip", "install",
+        f"git+https://github.com/junclemente/jcds.git@{branch}",
+    ])
 else:
     print(f"'{package_name}' is already installed.")
 
 from jcds import eda as jeda
 from jcds import reports as jrep
+from jcds import transform as jtrf
+from jcds import charts as jvis
 ```
+
+> 💡 Set `branch = "develop"` to always pull the latest development version. Switch to `branch = "main"` or a version tag like `branch = "v0.3.0"` for stable use.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ pytest
 Run a specific test file:
 
 ```bash
-pytest tests/unit/test_eda_helpers.py
+pytest tests/test_eda_helpers.py
 ```
 
 Measure test coverage:

--- a/README.md
+++ b/README.md
@@ -226,3 +226,28 @@ This project follows [Conventional Commits](https://www.conventionalcommits.org/
 | `ci`       | CI/CD config changes               | `ci: update GitHub Actions workflow`         |
 
 Used for consistent history and release tracking. 
+
+---
+
+## 🌿 Branch & Release Workflow
+
+This project uses **squash merge** from `develop` → `main` to keep a clean commit history.
+
+### After every PR merge into `main`:
+
+After merging, reset `develop` to match `main`:
+```bash
+git checkout develop
+git reset --hard origin/main
+git push origin develop --force-with-lease
+```
+
+> ⚠️ This is required after every merge because squash merge creates a new commit on `main` that `develop` doesn't recognize.
+
+### General flow:
+
+1. Do all work on `develop`
+2. Open PR: `develop` → `main`
+3. Squash and merge
+4. Reset `develop` to `main` (steps above)
+5. Tag and publish release

--- a/README.md
+++ b/README.md
@@ -52,6 +52,37 @@ Installs:
 
 ---
 
+### 📓 Auto-install in Jupyter Notebooks
+
+If you're using `jcds` in a Jupyter notebook, add this snippet at the top of your notebook to automatically install it if it's not already present:
+```python
+import importlib
+import subprocess
+import sys
+
+# Check if jcds is installed; install from GitHub if not
+package_name = "jcds"
+
+if importlib.util.find_spec(package_name) is None:
+    print(f"'{package_name}' not found. Installing from GitHub...")
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "git+https://github.com/junclemente/jcds.git",
+        ]
+    )
+else:
+    print(f"'{package_name}' is already installed.")
+
+from jcds import eda as jeda
+from jcds import reports as jrep
+```
+
+---
+
 ### 🌐 Import with `httpimport`
 
 Use [`httpimport`](https://pypi.org/project/httpimport/) directly in Jupyter:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jcds"
-version = "0.2.8"
+version = "0.3.0"
 description = "Jun Clemente’s Data Science helper library for EDA, visualization, and analysis"
 readme = "README.md"
 requires-python = ">=3.7"

--- a/src/jcds/__init__.py
+++ b/src/jcds/__init__.py
@@ -3,36 +3,30 @@ from . import aws
 from . import dataio
 from . import reports
 from . import transform
+from . import charts 
 
-__all__ = ["eda", "aws", "dataio", "reports", 'transform', "help"]
+
+__all__ = ["eda", "aws", "dataio", "reports", "transform", "charts","help"]
+
+
 
 
 def help(func_name=None, namespace=None):
-    """
-    Unified help system for the jcds package.
-
-    Parameters
-    ----------
-    func_name : str or None
-        If provided, shows the docstring for the named function.
-        If None, lists all available public functions.
-    namespace : dict or None
-        Internal override used to pass a custom namespace.
-        If None, collects all callable functions from jcds submodules.
-    """
     import inspect as pyinspect
-    from jcds import eda, aws, dataio
+    from jcds import eda, aws, dataio, reports, transform, charts
 
     if namespace is None:
         namespace = {}
 
-        # Dynamically collect public callables from submodules
-        for mod in [eda, aws, dataio]:
-            for name in dir(mod):
-                # Skip all dunder names like __file__, __name__, etc.
+        for mod in [eda, aws, dataio, reports, transform, charts]:
+            # Use __all__ if available, otherwise fall back to dir()
+            names = getattr(mod, "__all__", dir(mod))
+            for name in names:
                 if name.startswith("__") and name.endswith("__"):
                     continue
-                obj = getattr(mod, name)
+                if name == "help":
+                    continue
+                obj = getattr(mod, name, None)
                 if callable(obj):
                     namespace[name] = obj
 

--- a/src/jcds/__init__.py
+++ b/src/jcds/__init__.py
@@ -2,8 +2,9 @@ from . import eda
 from . import aws
 from . import dataio
 from . import reports
+from . import transform
 
-__all__ = ["eda", "aws", "dataio", "reports", "help"]
+__all__ = ["eda", "aws", "dataio", "reports", 'transform', "help"]
 
 
 def help(func_name=None, namespace=None):

--- a/src/jcds/charts/__init__.py
+++ b/src/jcds/charts/__init__.py
@@ -3,7 +3,9 @@ import jcds.utils
 
 # Import your functions from internal files
 from .roc import plot_roc
+from .boxplots import outlier_boxplots
+from .missing import missing_data_heatmap
 
 help = jcds.utils._make_module_help(sys.modules[__name__])
 
-__all__ = ["plot_roc", "help"]
+__all__ = ["plot_roc", "outlier_boxplots", "missing_data_heatmap", "help"]

--- a/src/jcds/charts/__init__.py
+++ b/src/jcds/charts/__init__.py
@@ -5,7 +5,8 @@ import jcds.utils
 from .roc import plot_roc
 from .boxplots import outlier_boxplots
 from .missing import missing_data_heatmap
+from .correlation import correlation_heatmap
 
 help = jcds.utils._make_module_help(sys.modules[__name__])
 
-__all__ = ["plot_roc", "outlier_boxplots", "missing_data_heatmap", "help"]
+__all__ = ["plot_roc", "outlier_boxplots", "missing_data_heatmap", "correlation_heatmap", "help"]

--- a/src/jcds/charts/__init__.py
+++ b/src/jcds/charts/__init__.py
@@ -5,8 +5,15 @@ import jcds.utils
 from .roc import plot_roc
 from .boxplots import outlier_boxplots
 from .missing import missing_data_heatmap
+from .categorical import categorical_barplot
 from .correlation import correlation_heatmap
 
 help = jcds.utils._make_module_help(sys.modules[__name__])
 
-__all__ = ["plot_roc", "outlier_boxplots", "missing_data_heatmap", "correlation_heatmap", "help"]
+__all__ = ["plot_roc", 
+           "outlier_boxplots", 
+           "missing_data_heatmap", 
+           "correlation_heatmap", 
+           "categorical_barplot", 
+           "help"
+        ]

--- a/src/jcds/charts/boxplots.py
+++ b/src/jcds/charts/boxplots.py
@@ -1,0 +1,51 @@
+import matplotlib.pyplot as plt 
+import seaborn as sns 
+
+from jcds.eda.inspect import show_convar, show_binary_list
+
+
+def outlier_boxplots(dataframe, threshold=1.5, figsize=(14, 5)):
+    """
+    Plots boxplots for numeric (non-binary) columns with potential outliers.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+        The input DataFrame.
+    threshold : float, optional
+        IQR multiplier to define outliers. Default is 1.5.
+    figsize : tuple
+        Size of the figure.
+
+    Returns
+    -------
+    None
+    """
+    numeric_cols = show_convar(dataframe)
+    binary_info = show_binary_list(dataframe)
+    binary_cols = binary_info["binary_columns"] + binary_info["binary_with_nan"]
+
+    outlier_cols = [col for col in numeric_cols if col not in binary_cols]
+
+    if not outlier_cols:
+        print("No numeric (non-binary) columns available for boxplot.")
+        return
+
+    num_cols = len(outlier_cols)
+    ncols = min(3, num_cols)
+    nrows = (num_cols + ncols - 1) // ncols
+
+    fig, axes = plt.subplots(
+        nrows=nrows, ncols=ncols, figsize=(figsize[0], figsize[1] * nrows)
+    )
+    axes = axes.flatten() if num_cols > 1 else [axes]
+
+    for ax, col in zip(axes, outlier_cols):
+        sns.boxplot(y=dataframe[col], ax=ax)
+        ax.set_title(col)
+
+    for ax in axes[num_cols:]:
+        ax.axis("off")
+
+    plt.tight_layout()
+    plt.show()

--- a/src/jcds/charts/categorical.py
+++ b/src/jcds/charts/categorical.py
@@ -1,0 +1,31 @@
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+
+def categorical_barplot(series, title=None, figsize=(10, 6)):
+    """
+    Plots a bar chart for a categorical variable.
+
+    Parameters
+    ----------
+    series : pd.Series
+        The categorical column to plot.
+    title : str, optional
+        Title for the plot.
+    figsize : tuple, optional
+        Figure size. Default is (10, 6).
+
+    Returns
+    -------
+    None
+    """
+    counts = series.value_counts(dropna=False)
+    fig, ax = plt.subplots(figsize=figsize)
+    sns.barplot(x=counts.index.astype(str), y=counts.values, ax=ax)
+    plt.xticks(rotation=45, ha="right")
+    ax.set_title(title or f"Distribution of {series.name}")
+    ax.set_xlabel(series.name)
+    ax.set_ylabel("Count")
+    plt.tight_layout()
+    plt.show()
+    plt.close(fig)

--- a/src/jcds/charts/correlation.py
+++ b/src/jcds/charts/correlation.py
@@ -1,0 +1,30 @@
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+
+def correlation_heatmap(dataframe, method="pearson", title="Correlation Heatmap", figsize=(10, 8)):
+    """
+    Plots a heatmap of feature correlations.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+        DataFrame to analyze.
+    method : str, optional
+        Correlation method ('pearson', 'kendall', 'spearman'). Default is 'pearson'.
+    title : str, optional
+        Title for the heatmap. Default is 'Correlation Heatmap'.
+    figsize : tuple, optional
+        Figure size. Default is (10, 8).
+
+    Returns
+    -------
+    None
+    """
+    corr = dataframe.corr(method=method)
+    fig, ax = plt.subplots(figsize=figsize)
+    sns.heatmap(corr, annot=True, cmap="coolwarm", fmt=".2f", square=True, ax=ax)
+    ax.set_title(title)
+    plt.tight_layout()
+    plt.show()
+    plt.close(fig)

--- a/src/jcds/charts/missing.py
+++ b/src/jcds/charts/missing.py
@@ -1,0 +1,34 @@
+import matplotlib.pyplot as plt 
+import seaborn as sns 
+
+def missing_data_heatmap(dataframe, figsize=(12, 10), cmap="viridis", title = "Missing Data Heatmap", xlabel = "Columns", ylabel = "Rows"): 
+    """
+    Plots a heatmap of missing values across the DataFrame.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+        The input DataFrame.
+    figsize : tuple, optional
+        Figure size. Default is (12, 10).
+    cmap : str, optional
+        Colormap for the heatmap. Default is 'viridis'.
+    title : str, optional
+        Title of the plot. Default is 'Missing Data Heatmap'.
+    xlabel : str, optional
+        Label for the x-axis. Default is 'Columns'.
+    ylabel : str, optional
+        Label for the y-axis. Default is 'Rows'.
+
+    Returns
+    -------
+    None
+    """
+    fig, ax = plt.subplots(figsize=figsize) 
+    sns.heatmap(dataframe.isnull(), cbar=False, cmap=cmap, ax=ax) 
+    ax.set_title(title, fontsize=14) 
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel(ylabel)
+    plt.tight_layout() 
+    plt.show() 
+    plt.close(fig) 

--- a/src/jcds/eda/__init__.py
+++ b/src/jcds/eda/__init__.py
@@ -30,9 +30,11 @@ from .inspect import (
     count_id_like_columns,
     get_dtype_summary,
     show_missing_summary,
+    show_null_rows, 
+    show_null_cols,
 )
 
-from .outliers import detect_outliers_iqr, plot_outlier_boxplots
+from .outliers import detect_outliers_iqr, plot_outlier_boxplots, plot_missing_heatmap
 
 from .reports import dqr_cat, dqr_cont, quick_report, long_report, display_all_col_head
 
@@ -98,6 +100,7 @@ __all__ = [
     "show_missing_summary",
     "detect_outliers_iqr",
     "plot_outlier_boxplots",
+    "plot_missing_heatmap",
     "delete_columns",
     "convert_to_int",
     "convert_to_categorical",
@@ -106,5 +109,7 @@ __all__ = [
     "convert_to_numeric",
     "clean_column_names",
     "convert_to_bool",
+    "show_null_rows",
+    "show_null_cols", 
     "help",
 ]

--- a/src/jcds/eda/__init__.py
+++ b/src/jcds/eda/__init__.py
@@ -34,7 +34,7 @@ from .inspect import (
     show_null_cols,
 )
 
-from .outliers import detect_outliers_iqr, plot_outlier_boxplots, plot_missing_heatmap
+from .outliers import detect_outliers_iqr, plot_outlier_boxplots
 
 from .reports import dqr_cat, dqr_cont, quick_report, long_report, display_all_col_head
 
@@ -100,7 +100,6 @@ __all__ = [
     "show_missing_summary",
     "detect_outliers_iqr",
     "plot_outlier_boxplots",
-    "plot_missing_heatmap",
     "delete_columns",
     "convert_to_int",
     "convert_to_categorical",

--- a/src/jcds/eda/inspect.py
+++ b/src/jcds/eda/inspect.py
@@ -598,3 +598,37 @@ def show_missing_summary(dataframe, sort=True, threshold=0.0):
         summary = dict(sorted(summary.items(), key=lambda x: x[1][0], reverse=True))
 
     return summary
+
+
+def show_null_rows(dataframe):
+    """
+    Returns rows that contain at least one null value.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+        The input pandas DataFrame.
+
+    Returns
+    -------
+    pd.DataFrame
+        Subset of rows containing at least one null value.
+    """
+    return dataframe[dataframe.isnull().any(axis=1)]
+
+
+def show_null_cols(dataframe):
+    """
+    Returns columns that contain at least one null value.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+        The input pandas DataFrame.
+
+    Returns
+    -------
+    pd.DataFrame
+        Subset of columns containing at least one null value.
+    """
+    return dataframe.loc[:, dataframe.isnull().any()]

--- a/src/jcds/eda/inspect.py
+++ b/src/jcds/eda/inspect.py
@@ -160,7 +160,7 @@ def show_convar(dataframe):
     """
 
     cont_features = dataframe.select_dtypes(
-        exclude=["category", "object"]
+        exclude=["category", "object", "datetimetz", "datetime64"]
     ).columns.tolist()
     return cont_features
 

--- a/src/jcds/eda/inspect.py
+++ b/src/jcds/eda/inspect.py
@@ -504,7 +504,7 @@ def show_possible_datetime_columns(dataframe, sample_size=5):
 def show_mixed_type_columns(df):
     mixed_cols = []
     for col in df.columns:
-        types = df[col].dropna().map(type).nunique()
+        types = df[col].dropna().map(lambda x: type(x).__name__).nunique()
         if types > 1:
             mixed_cols.append(col)
     return mixed_cols

--- a/src/jcds/eda/inspect.py
+++ b/src/jcds/eda/inspect.py
@@ -492,7 +492,7 @@ def show_possible_datetime_columns(dataframe, sample_size=5):
     for col in dataframe.select_dtypes(include="object").columns:
         sample_values = dataframe[col].dropna().head(sample_size)
         parse_attempts = sample_values.apply(
-            lambda x: pd.to_datetime(x, errors="coerce")
+            lambda x: pd.to_datetime(x, errors="coerce", utc=True)
         )
         success_ratio = parse_attempts.notna().mean()
         if success_ratio >= 0.8:  # 80% of values parse as dates

--- a/src/jcds/eda/inspect.py
+++ b/src/jcds/eda/inspect.py
@@ -504,7 +504,7 @@ def show_possible_datetime_columns(dataframe, sample_size=5):
 def show_mixed_type_columns(df):
     mixed_cols = []
     for col in df.columns:
-        types = df[col].map(type).nunique()
+        types = df[col].dropna().map(type).nunique()
         if types > 1:
             mixed_cols.append(col)
     return mixed_cols

--- a/src/jcds/eda/multivariate.py
+++ b/src/jcds/eda/multivariate.py
@@ -2,6 +2,9 @@ import pandas as pd
 import seaborn as sns
 import matplotlib.pyplot as plt
 
+from jcds.utils import deprecated
+from jcds.charts.correlation import correlation_heatmap as _correlation_heatmap
+
 
 def correlation_matrix(dataframe, method="pearson"):
     """
@@ -21,27 +24,10 @@ def correlation_matrix(dataframe, method="pearson"):
     """
     return dataframe.corr(method=method)
 
-
-def plot_correlation_heatmap(dataframe, method="pearson", title="Correlation Heatmap"):
-    """
-    Plots a heatmap of feature correlations.
-
-    Parameters
-    ----------
-    dataframe : pd.DataFrame
-        DataFrame to analyze.
-    method : str
-        Correlation method ('pearson', 'kendall', 'spearman').
-    title : str
-        Title for the heatmap.
-
-    Returns
-    -------
-    None
-    """
-    corr = dataframe.corr(method=method)
-    plt.figure(figsize=(10, 8))
-    sns.heatmap(corr, annot=True, cmap="coolwarm", fmt=".2f", square=True)
-    plt.title(title)
-    plt.tight_layout()
-    plt.show()
+@deprecated(
+        reason="Use jcds.charts.correlation_heatmap() instead.",
+        version="0.4.0"
+)
+def plot_correlation_heatmap(dataframe, method="pearson", title="Correlation Heatmap", figsize=(10, 8)):
+    """Deprecated. Use jcds.charts.correlation_heatmap() instead."""
+    return _correlation_heatmap(dataframe, method=method, title=title, figsize=figsize)

--- a/src/jcds/eda/outliers.py
+++ b/src/jcds/eda/outliers.py
@@ -97,3 +97,30 @@ def plot_outlier_boxplots(dataframe, threshold=1.5, figsize=(14, 5)):
 
     plt.tight_layout()
     plt.show()
+
+
+def plot_missing_heatmap(dataframe, figsize=(12, 10), cmap="viridis"):
+    """
+    Plots a heatmap of missing values across the DataFrame.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+        The input DataFrame.
+    figsize : tuple, optional
+        Figure size. Default is (12, 10).
+    cmap : str, optional
+        Colormap for the heatmap. Default is 'viridis'.
+
+    Returns
+    -------
+    None
+    """
+    fig, ax = plt.subplots(figsize=figsize)
+    sns.heatmap(dataframe.isnull(), cbar=False, cmap=cmap, ax=ax)
+    ax.set_title("Missing Data Heatmap", fontsize=14)
+    ax.set_xlabel("Features")
+    ax.set_ylabel("Records")
+    plt.tight_layout()
+    plt.show()
+    plt.close(fig)

--- a/src/jcds/eda/outliers.py
+++ b/src/jcds/eda/outliers.py
@@ -1,4 +1,5 @@
 from jcds.eda.inspect import show_convar, show_binary_list
+from jcds.utils import deprecated
 import pandas as pd
 import matplotlib.pyplot as plt
 import seaborn as sns
@@ -51,10 +52,14 @@ def detect_outliers_iqr(dataframe, threshold=1.5, return_mask=False):
 
     return outlier_mask if return_mask else outlier_counts
 
-
+@deprecated( 
+    reason="Use jcds.charts.outlier_boxplots() instead.", 
+    version="0.4.0"
+)
 def plot_outlier_boxplots(dataframe, threshold=1.5, figsize=(14, 5)):
     """
     Plots boxplots for numeric (non-binary) columns with potential outliers.
+    *** Deprecated. Use jcds.charts.outlier_boxplots() instead. 
 
     Parameters
     ----------
@@ -98,29 +103,3 @@ def plot_outlier_boxplots(dataframe, threshold=1.5, figsize=(14, 5)):
     plt.tight_layout()
     plt.show()
 
-
-def plot_missing_heatmap(dataframe, figsize=(12, 10), cmap="viridis"):
-    """
-    Plots a heatmap of missing values across the DataFrame.
-
-    Parameters
-    ----------
-    dataframe : pd.DataFrame
-        The input DataFrame.
-    figsize : tuple, optional
-        Figure size. Default is (12, 10).
-    cmap : str, optional
-        Colormap for the heatmap. Default is 'viridis'.
-
-    Returns
-    -------
-    None
-    """
-    fig, ax = plt.subplots(figsize=figsize)
-    sns.heatmap(dataframe.isnull(), cbar=False, cmap=cmap, ax=ax)
-    ax.set_title("Missing Data Heatmap", fontsize=14)
-    ax.set_xlabel("Features")
-    ax.set_ylabel("Records")
-    plt.tight_layout()
-    plt.show()
-    plt.close(fig)

--- a/src/jcds/eda/transform.py
+++ b/src/jcds/eda/transform.py
@@ -1,7 +1,12 @@
 import pandas as pd
 import re
 
+from jcds.utils import deprecated 
 
+@deprecated(
+    reason="This function will be moved to the jcds.transform module.",
+    version="0.4.0"
+)
 def rename_column(dataframe, oldname, newname):
     """
     Rename a column in a pandas DataFrame.
@@ -29,7 +34,10 @@ def rename_column(dataframe, oldname, newname):
         raise ValueError(f"Column '{oldname}' not found in DataFrame.")
     return dataframe.rename(columns={oldname: newname})
 
-
+@deprecated(
+    reason="This function will be moved to the jcds.transform module.",
+    version="0.4.0"
+)
 def delete_columns(dataframe, columns_to_drop, inplace=False):
     """
     Drop one or more columns from a pandas DataFrame.
@@ -69,7 +77,10 @@ def delete_columns(dataframe, columns_to_drop, inplace=False):
     else:
         return dataframe.drop(columns=columns_to_drop)
 
-
+@deprecated(
+    reason="This function will be moved to the jcds.transform module.",
+    version="0.4.0"
+)
 def convert_to_int(
     dataframe: pd.DataFrame,
     columns: list[str] | None = None,
@@ -133,7 +144,10 @@ def convert_to_int(
     if not inplace:
         return df
 
-
+@deprecated(
+    reason="This function will be moved to the jcds.transform module.",
+    version="0.4.0"
+)
 def convert_to_numeric(
     dataframe, columns, errors="raise", downcast=None, inplace=False
 ):
@@ -174,7 +188,10 @@ def convert_to_numeric(
 
     return df
 
-
+@deprecated(
+    reason="This function will be moved to the jcds.transform module.",
+    version="0.4.0"
+)
 def convert_to_categorical(
     dataframe: pd.DataFrame,
     columns: list[str] | None = None,
@@ -229,7 +246,10 @@ def convert_to_categorical(
     if not inplace:
         return df
 
-
+@deprecated(
+    reason="This function will be moved to the jcds.transform module.",
+    version="0.4.0"
+)
 def convert_to_object(
     dataframe: pd.DataFrame, columns: list[str], inplace: bool = False
 ) -> pd.DataFrame | None:
@@ -274,7 +294,10 @@ def convert_to_object(
     if not inplace:
         return df
 
-
+@deprecated(
+    reason="This function will be moved to the jcds.transform module.",
+    version="0.4.0"
+)
 def convert_to_datetime(dataframe, columns, format=None, errors="raise", inplace=False):
     """
     Converts one or more DataFrame columns to datetime dtype.
@@ -317,7 +340,10 @@ def convert_to_datetime(dataframe, columns, format=None, errors="raise", inplace
 
     return df
 
-
+@deprecated(
+    reason="This function will be moved to the jcds.transform module.",
+    version="0.4.0"
+)
 def clean_column_names(dataframe, inplace=False):
     """
     Cleans DataFrame column names by stripping whitespace, lowercasing, and replacing non-alphanumeric characters with underscores.
@@ -352,7 +378,10 @@ def clean_column_names(dataframe, inplace=False):
     return df
 
 
-
+@deprecated(
+    reason="This function will be moved to the jcds.transform module.",
+    version="0.4.0"
+)
 def convert_to_bool(dataframe, columns, true_values=None, false_values=None, errors='raise', inplace=False):
     """
     Converts one or more DataFrame columns to boolean dtype based on specified true/false values.

--- a/src/jcds/eda/transform.py
+++ b/src/jcds/eda/transform.py
@@ -336,11 +336,17 @@ def clean_column_names(dataframe, inplace=False):
     """
     df = dataframe if inplace else dataframe.copy()
     mapping = {}
+    seen = {}
     for col in df.columns:
         new_col = col.strip()
         new_col = new_col.lower()
         new_col = re.sub(r"[^0-9a-z]+", "_", new_col)
         new_col = re.sub(r"__+", "_", new_col).strip("_")
+        if new_col in seen: 
+            seen[new_col] += 1
+            new_col = f"{new_col}_{seen[new_col]}"
+        else: 
+            seen[new_col] = 0 
         mapping[col] = new_col
     df.rename(columns=mapping, inplace=True)
     return df

--- a/src/jcds/eda/univariate.py
+++ b/src/jcds/eda/univariate.py
@@ -2,6 +2,9 @@ import pandas as pd
 import matplotlib.pyplot as plt
 import seaborn as sns
 
+from jcds.utils import deprecated
+from jcds.charts.categorical import categorical_barplot as _categorical_barplot
+
 
 def describe_categorical(series):
     """
@@ -24,26 +27,10 @@ def describe_categorical(series):
     return pd.DataFrame({"Count": counts, "Percent": percents.round(2)})
 
 
-def plot_categorical(series, title=None):
-    """
-    Plots a bar chart for a categorical variable.
-
-    Parameters
-    ----------
-    series : pd.Series
-        The categorical column to plot.
-    title : str, optional
-        Title for the plot.
-
-    Returns
-    -------
-    None
-    """
-    counts = series.value_counts(dropna=False)
-    sns.barplot(x=counts.index.astype(str), y=counts.values)
-    plt.xticks(rotation=45)
-    plt.title(title or f"Distribution of {series.name}")
-    plt.xlabel(series.name)
-    plt.ylabel("Count")
-    plt.tight_layout()
-    plt.show()
+@deprecated(
+        reason="Use jcds.charts.categorical_barplot() instead.",
+        version="0.4.0"
+)
+def plot_categorical(series, title=None, figsize=(10, 6)):
+    """Deprecated. Use jcds.charts.categorical_barplot() instead."""
+    return _categorical_barplot(series, title=title, figsize=figsize)

--- a/src/jcds/reports/reports.py
+++ b/src/jcds/reports/reports.py
@@ -30,7 +30,8 @@ from jcds.eda import (
 # from jcds.utils.formatting import render_html_block
 
 
-def data_info(dataframe, show_columns=False):
+
+def data_info(dataframe, show_columns=True):
     """
     Summarize the dataset's shape, memory usage, duplicates, and variable types.
 
@@ -96,7 +97,7 @@ def data_info(dataframe, show_columns=False):
         print(f" * Columns: {mixed_columns}")
 
 
-def data_cardinality(dataframe, show_columns=False):
+def data_cardinality(dataframe, show_columns=True):
     """
     Summarizes the cardinality of the columns in the dataset.
 
@@ -173,7 +174,7 @@ def data_cardinality(dataframe, show_columns=False):
             print(f" * Columns: {highcardvars}")
 
 
-def data_quality(dataframe, show_columns=False):
+def data_quality(dataframe, show_columns=True):
     """
     Print a comprehensive data quality report for the given DataFrame.
 

--- a/src/jcds/transform/__init__.py
+++ b/src/jcds/transform/__init__.py
@@ -1,0 +1,18 @@
+import sys
+import jcds.utils
+
+from .convert import to_int, to_float, to_numeric, to_str
+from .clean import clean_column_names, rename_column, delete_columns
+
+help = jcds.utils._make_module_help(sys.modules[__name__])
+
+__all__ = [
+    "to_int",
+    "to_float",
+    "to_numeric",
+    "to_str",
+    "clean_column_names",
+    "rename_column",
+    "delete_columns",
+    "help",
+]

--- a/src/jcds/transform/__init__.py
+++ b/src/jcds/transform/__init__.py
@@ -1,18 +1,12 @@
 import sys
 import jcds.utils
 
-from .convert import to_int, to_float, to_numeric, to_str
+from .convert import to_int, to_float, to_numeric, to_str, to_categorical, to_bool, to_datetime, to_object
 from .clean import clean_column_names, rename_column, delete_columns
 
-help = jcds.utils._make_module_help(sys.modules[__name__])
-
 __all__ = [
-    "to_int",
-    "to_float",
-    "to_numeric",
-    "to_str",
-    "clean_column_names",
-    "rename_column",
-    "delete_columns",
+    "to_int", "to_float", "to_numeric", "to_str",
+    "to_categorical", "to_bool", "to_datetime", "to_object",
+    "clean_column_names", "rename_column", "delete_columns",
     "help",
 ]

--- a/src/jcds/transform/clean.py
+++ b/src/jcds/transform/clean.py
@@ -1,0 +1,76 @@
+import re
+import pandas as pd
+
+
+def rename_column(dataframe, oldname, newname):
+    """
+    Rename a column in a pandas DataFrame.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+    oldname : str
+    newname : str
+
+    Returns
+    -------
+    pd.DataFrame
+    """
+    if oldname not in dataframe.columns:
+        raise ValueError(f"Column '{oldname}' not found in DataFrame.")
+    return dataframe.rename(columns={oldname: newname})
+
+
+def delete_columns(dataframe, columns_to_drop, inplace=False):
+    """
+    Drop one or more columns from a pandas DataFrame.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+    columns_to_drop : list of str
+    inplace : bool, optional
+        Default is False.
+
+    Returns
+    -------
+    pd.DataFrame or None
+    """
+    if inplace:
+        dataframe.drop(columns=columns_to_drop, inplace=True)
+        return None
+    else:
+        return dataframe.drop(columns=columns_to_drop)
+
+
+def clean_column_names(dataframe, inplace=False):
+    """
+    Clean column names by stripping whitespace, lowercasing, and replacing
+    non-alphanumeric characters with underscores. Handles duplicate names
+    by appending a numeric suffix.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+    inplace : bool, optional
+        Default is False.
+
+    Returns
+    -------
+    pd.DataFrame or None
+    """
+    df = dataframe if inplace else dataframe.copy()
+    mapping = {}
+    seen = {}
+    for col in df.columns:
+        new_col = col.strip().lower()
+        new_col = re.sub(r"[^0-9a-z]+", "_", new_col)
+        new_col = re.sub(r"__+", "_", new_col).strip("_")
+        if new_col in seen:
+            seen[new_col] += 1
+            new_col = f"{new_col}_{seen[new_col]}"
+        else:
+            seen[new_col] = 0
+        mapping[col] = new_col
+    df.rename(columns=mapping, inplace=True)
+    return df

--- a/src/jcds/transform/convert.py
+++ b/src/jcds/transform/convert.py
@@ -131,3 +131,151 @@ def to_str(dataframe, columns, inplace=False):
 
     if not inplace:
         return df
+    
+
+def to_categorical(dataframe, columns=None, ordered=False, inplace=False):
+    """
+    Convert one or more columns to pandas Categorical dtype.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+    columns : list of str or None
+        Columns to convert. If None, converts all object/string columns.
+    ordered : bool, optional
+        Whether the Categorical should be ordered. Default is False.
+    inplace : bool, optional
+        Default is False.
+
+    Returns
+    -------
+    pd.DataFrame or None
+    """
+    df = dataframe if inplace else dataframe.copy()
+
+    if columns is None:
+        cols = df.select_dtypes(include=["object", "string"]).columns
+    else:
+        missing = set(columns) - set(df.columns)
+        if missing:
+            raise ValueError(f"Columns not found: {missing}")
+        cols = columns
+
+    for col in cols:
+        df[col] = df[col].astype(pd.CategoricalDtype(ordered=ordered))
+
+    if not inplace:
+        return df
+
+
+def to_bool(dataframe, columns, true_values=None, false_values=None, errors="raise", inplace=False):
+    """
+    Convert one or more columns to boolean dtype.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+    columns : str or list of str
+        Columns to convert.
+    true_values : list, optional
+        Values to interpret as True. Default: ['true', '1', 'yes', 'y', 't']
+    false_values : list, optional
+        Values to interpret as False. Default: ['false', '0', 'no', 'n', 'f']
+    errors : {'raise', 'coerce'}, optional
+        Default is 'raise'.
+    inplace : bool, optional
+        Default is False.
+
+    Returns
+    -------
+    pd.DataFrame or None
+    """
+    df = dataframe if inplace else dataframe.copy()
+    cols = [columns] if isinstance(columns, str) else list(columns)
+
+    missing = set(cols) - set(df.columns)
+    if missing:
+        raise KeyError(f"Columns not found in DataFrame: {missing}")
+
+    default_true = {"true", "1", "yes", "y", "t"}
+    default_false = {"false", "0", "no", "n", "f"}
+    trues = set(v.lower() for v in (true_values or default_true))
+    falses = set(v.lower() for v in (false_values or default_false))
+
+    for col in cols:
+        series = df[col].astype(str).str.strip().str.lower()
+        result = pd.Series(pd.NA, index=series.index, dtype="boolean")
+        mask_true = series.isin(trues)
+        mask_false = series.isin(falses)
+        result[mask_true] = True
+        result[mask_false] = False
+        unknown = ~(mask_true | mask_false)
+        if errors == "raise" and unknown.any():
+            bad_vals = series[unknown].unique()
+            raise ValueError(f"Unrecognized boolean values in column {col}: {bad_vals}")
+        df[col] = result
+
+    if not inplace:
+        return df
+
+
+def to_datetime(dataframe, columns, format=None, errors="raise", inplace=False):
+    """
+    Convert one or more columns to datetime dtype.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+    columns : str or list of str
+        Columns to convert.
+    format : str, optional
+        Datetime format string.
+    errors : {'raise', 'coerce', 'ignore'}, optional
+        Default is 'raise'.
+    inplace : bool, optional
+        Default is False.
+
+    Returns
+    -------
+    pd.DataFrame or None
+    """
+    df = dataframe if inplace else dataframe.copy()
+    cols = [columns] if isinstance(columns, str) else list(columns)
+
+    missing = set(cols) - set(df.columns)
+    if missing:
+        raise KeyError(f"Columns not found in DataFrame: {missing}")
+
+    for col in cols:
+        df[col] = pd.to_datetime(df[col], format=format, errors=errors)
+
+    return df
+
+
+def to_object(dataframe, columns, inplace=False):
+    """
+    Cast one or more columns to object dtype.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+    columns : list of str
+        Columns to convert.
+    inplace : bool, optional
+        Default is False.
+
+    Returns
+    -------
+    pd.DataFrame or None
+    """
+    df = dataframe if inplace else dataframe.copy()
+
+    missing = set(columns) - set(df.columns)
+    if missing:
+        raise ValueError(f"Columns not found: {missing}")
+
+    for col in columns:
+        df[col] = df[col].astype("object")
+
+    if not inplace:
+        return df

--- a/src/jcds/transform/convert.py
+++ b/src/jcds/transform/convert.py
@@ -1,0 +1,133 @@
+import pandas as pd
+
+
+def to_int(dataframe, columns=None, unsigned=False, errors="raise", inplace=False):
+    """
+    Cast one or more columns to the smallest integer dtype.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+    columns : list of str or None
+        Columns to convert. If None, converts all numeric columns.
+    unsigned : bool, optional
+        If True, downcast to unsigned int. Default is False.
+    errors : {'raise', 'coerce'}, optional
+        How to handle non-convertible values. Default is 'raise'.
+    inplace : bool, optional
+        If True, modify in place. Default is False.
+
+    Returns
+    -------
+    pd.DataFrame or None
+    """
+    df = dataframe if inplace else dataframe.copy()
+
+    if columns is None:
+        cols = df.select_dtypes(include="number").columns
+    else:
+        missing = set(columns) - set(df.columns)
+        if missing:
+            raise ValueError(f"Columns not found in DataFrame: {missing}")
+        cols = columns
+
+    kind = "unsigned" if unsigned else "integer"
+    for col in cols:
+        df[col] = pd.to_numeric(df[col], downcast=kind, errors=errors)
+
+    if not inplace:
+        return df
+
+
+def to_float(dataframe, columns, errors="raise", inplace=False):
+    """
+    Cast one or more columns to float dtype.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+    columns : str or list of str
+        Columns to convert.
+    errors : {'raise', 'coerce', 'ignore'}, optional
+        How to handle non-convertible values. Default is 'raise'.
+    inplace : bool, optional
+        If True, modify in place. Default is False.
+
+    Returns
+    -------
+    pd.DataFrame or None
+    """
+    df = dataframe if inplace else dataframe.copy()
+    cols = [columns] if isinstance(columns, str) else list(columns)
+
+    missing = set(cols) - set(df.columns)
+    if missing:
+        raise ValueError(f"Columns not found in DataFrame: {missing}")
+
+    for col in cols:
+        df[col] = pd.to_numeric(df[col], errors=errors, downcast="float")
+
+    if not inplace:
+        return df
+
+
+def to_numeric(dataframe, columns, errors="raise", downcast=None, inplace=False):
+    """
+    Convert one or more columns to numeric dtype.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+    columns : str or list of str
+        Columns to convert.
+    errors : {'raise', 'coerce', 'ignore'}, optional
+        Default is 'raise'.
+    downcast : {'integer', 'signed', 'unsigned', 'float'}, optional
+    inplace : bool, optional
+        Default is False.
+
+    Returns
+    -------
+    pd.DataFrame or None
+    """
+    df = dataframe if inplace else dataframe.copy()
+    cols = [columns] if isinstance(columns, str) else list(columns)
+
+    missing = set(cols) - set(df.columns)
+    if missing:
+        raise KeyError(f"Columns not found in DataFrame: {missing}")
+
+    for col in cols:
+        df[col] = pd.to_numeric(df[col], errors=errors, downcast=downcast)
+
+    return df
+
+
+def to_str(dataframe, columns, inplace=False):
+    """
+    Convert one or more columns to string dtype.
+
+    Parameters
+    ----------
+    dataframe : pd.DataFrame
+    columns : str or list of str
+        Columns to convert.
+    inplace : bool, optional
+        Default is False.
+
+    Returns
+    -------
+    pd.DataFrame or None
+    """
+    df = dataframe if inplace else dataframe.copy()
+    cols = [columns] if isinstance(columns, str) else list(columns)
+
+    missing = set(cols) - set(df.columns)
+    if missing:
+        raise ValueError(f"Columns not found in DataFrame: {missing}")
+
+    for col in cols:
+        df[col] = df[col].astype(str)
+
+    if not inplace:
+        return df

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -1,0 +1,41 @@
+import jcds
+
+
+def test_help_lists_functions(capsys):
+    """Test that jcds.help() prints available functions."""
+    jcds.help()
+    captured = capsys.readouterr()
+    assert "Available functions in jcds:" in captured.out
+    assert "data_info" in captured.out
+    assert "data_quality" in captured.out
+
+
+def test_help_shows_docstring(capsys):
+    """Test that jcds.help(func_name) shows a docstring."""
+    jcds.help("data_info")
+    captured = capsys.readouterr()
+    assert "Help for 'data_info'" in captured.out
+
+
+def test_help_unknown_function(capsys):
+    """Test that jcds.help() handles unknown function gracefully."""
+    jcds.help("nonexistent_function")
+    captured = capsys.readouterr()
+    assert "not found" in captured.out
+
+
+def test_help_includes_transform_functions(capsys):
+    """Test that jcds.help() includes transform module functions."""
+    jcds.help()
+    captured = capsys.readouterr()
+    assert "to_int" in captured.out
+    assert "clean_column_names" in captured.out
+
+
+def test_help_includes_charts_functions(capsys):
+    """Test that jcds.help() includes charts module functions."""
+    jcds.help()
+    captured = capsys.readouterr()
+    assert "correlation_heatmap" in captured.out
+    assert "outlier_boxplots" in captured.out
+    assert "missing_data_heatmap" in captured.out

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -141,6 +141,11 @@ def test_show_mixed_type_columns(mixed_type_df):
     assert "more_mixed" in result
     assert "clean" not in result
 
+def test_show_mixed_type_columns_ignores_nan(sample_df):
+    # sample_df has NaN values in string columns — should not be flagged as mixed
+    result = eda.show_mixed_type_columns(sample_df)
+    assert "Gender" not in result  # Gender has NaN but is still just strings
+
 
 def test_count_id_like_columns(id_like_df):
     result = eda.count_id_like_columns(id_like_df, threshold=0.95)

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -149,6 +149,12 @@ def test_show_mixed_type_columns_ignores_nan(sample_df):
     result = eda.show_mixed_type_columns(sample_df)
     assert "Gender" not in result  # Gender has NaN but is still just strings
 
+def test_show_mixed_type_columns_ignores_numpy_str(sample_df):
+    # Converting to str can produce numpy.str_ mixed with str — should not be flagged
+    df = sample_df.copy()
+    df["Gender"] = df["Gender"].astype(str)
+    result = eda.show_mixed_type_columns(df)
+    assert "Gender" not in result
 
 def test_count_id_like_columns(id_like_df):
     result = eda.count_id_like_columns(id_like_df, threshold=0.95)

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -27,6 +27,9 @@ def test_show_convar_returns_numerical_columns(sample_df):
     assert "Gender" not in con_vars
     assert isinstance(con_vars, list)
 
+def test_show_convar_excludes_datetime(datetime_parsed_df):
+    result = eda.show_convar(datetime_parsed_df)
+    assert "timestamp" not in result
 
 def test_show_lowcardvars_filters_by_cardinality(lowcard_df):
     result = eda.show_lowcardvars(lowcard_df, max_unique=3)

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -204,3 +204,27 @@ def test_show_dimensions_returns_correct_values(sample_df):
     assert cols == 5
     assert size == 50
     assert isinstance(memory_use, float)
+
+
+def test_show_null_rows_returns_only_null_rows(sample_df):
+    result = eda.show_null_rows(sample_df)
+    assert result.isnull().any(axis=1).all()
+    assert len(result) < len(sample_df)
+
+
+def test_show_null_rows_empty_when_no_nulls(sample_df):
+    df = sample_df.dropna()
+    result = eda.show_null_rows(df)
+    assert len(result) == 0
+
+
+def test_show_null_cols_returns_only_null_cols(missing_data_df):
+    result = eda.show_null_cols(missing_data_df)
+    assert result.isnull().any(axis=0).all()
+    assert len(result.columns) < len(missing_data_df.columns)
+
+
+def test_show_null_cols_empty_when_no_nulls(sample_df):
+    df = sample_df.dropna()
+    result = eda.show_null_cols(df)
+    assert len(result.columns) == 0

--- a/tests/test_multivariate.py
+++ b/tests/test_multivariate.py
@@ -12,3 +12,11 @@ def test_correlation_matrix_returns_dataframe(sample_df):
 
 def test_plot_correlation_heatmap_runs_without_error(sample_df):
     multivariate.plot_correlation_heatmap(sample_df[["Age", "Income"]])
+
+def test_correlation_heatmap_charts(sample_df):
+    """Test that charts.correlation_heatmap runs without error."""
+    from jcds import charts
+    try:
+        charts.correlation_heatmap(sample_df[["Age", "Income"]])
+    except Exception as e:
+        pytest.fail(f"charts.correlation_heatmap raised an exception: {e}")

--- a/tests/test_outliers.py
+++ b/tests/test_outliers.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from jcds.eda import outliers
+from jcds import charts 
 
 
 def test_plot_outlier_boxplots(sample_df):
@@ -9,9 +10,16 @@ def test_plot_outlier_boxplots(sample_df):
         pytest.fail(f"plot_outlier_boxplots raised an exception: {e}")
 
 
-def test_plot_missing_heatmap(sample_df):
-    """Test that plot_missing_heatmap runs without error."""
+def test_outlier_boxplots(sample_df):
     try:
-        outliers.plot_missing_heatmap(sample_df)
+        charts.outlier_boxplots(sample_df)
     except Exception as e:
-        pytest.fail(f"plot_missing_heatmap raised an exception: {e}")
+        pytest.fail(f"charts.outlier_boxplots raised an exception: {e}")
+
+
+def test_missing_data_heatmap_charts(sample_df):
+    """Test that charts.plot_missing_heatmap runs without error."""
+    try:
+        charts.missing_data_heatmap(sample_df)
+    except Exception as e:
+        pytest.fail(f"charts.plot_missing_heatmap raised an exception: {e}")

--- a/tests/test_outliers.py
+++ b/tests/test_outliers.py
@@ -7,3 +7,11 @@ def test_plot_outlier_boxplots(sample_df):
         outliers.plot_outlier_boxplots(sample_df)
     except Exception as e:
         pytest.fail(f"plot_outlier_boxplots raised an exception: {e}")
+
+
+def test_plot_missing_heatmap(sample_df):
+    """Test that plot_missing_heatmap runs without error."""
+    try:
+        outliers.plot_missing_heatmap(sample_df)
+    except Exception as e:
+        pytest.fail(f"plot_missing_heatmap raised an exception: {e}")

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -10,6 +10,7 @@ from jcds.eda.transform import (
     convert_to_categorical,
     convert_to_object,
     convert_to_bool,
+    clean_column_names,
 )
 
 
@@ -225,3 +226,15 @@ def test_convert_to_bool_inplace(mixed_type_df):
     ret = convert_to_bool(df, "col", inplace=True)
     assert ret is df
     assert is_bool_dtype(df["col"].dtype)
+
+
+def test_clean_column_names_handles_collision():
+    df = pd.DataFrame(columns=["First Name", "First  Name", "Age"])
+    result = clean_column_names(df)
+    assert list(result.columns) == ["first_name", "first_name_1", "age"]
+
+
+def test_clean_column_names_handles_triple_collision():
+    df = pd.DataFrame(columns=["First Name", "First  Name", "First   Name", "Age"])
+    result = clean_column_names(df)
+    assert list(result.columns) == ["first_name", "first_name_1", "first_name_2", "age"]

--- a/tests/test_transform_module.py
+++ b/tests/test_transform_module.py
@@ -46,7 +46,55 @@ def test_to_str_missing_column_raises(unique_test_df):
     with pytest.raises(ValueError, match="Columns not found"):
         jtransform.to_str(unique_test_df, columns=["no_such_col"])
 
+# --- to_categorical ---
+def test_to_categorical_basic(unique_test_df):
+    result = jtransform.to_categorical(unique_test_df, columns=["Category"])
+    assert isinstance(result["Category"].dtype, pd.CategoricalDtype)
 
+
+def test_to_categorical_ordered(unique_test_df):
+    result = jtransform.to_categorical(unique_test_df, columns=["Category"], ordered=True)
+    assert result["Category"].dtype.ordered is True
+
+
+def test_to_categorical_missing_raises(sample_df):
+    with pytest.raises(ValueError, match="Columns not found"):
+        jtransform.to_categorical(sample_df, columns=["NoCol"])
+
+
+# --- to_bool ---
+def test_to_bool_basic(sample_df):
+    result = jtransform.to_bool(sample_df, "Subscribed")
+    assert result["Subscribed"].dtype.name == "boolean"
+
+
+def test_to_bool_missing_column_raises(sample_df):
+    with pytest.raises(KeyError):
+        jtransform.to_bool(sample_df, "does_not_exist")
+
+
+# --- to_datetime ---
+def test_to_datetime_basic(datetime_df):
+    result = jtransform.to_datetime(datetime_df, columns=["timestamp"])
+    assert pd.api.types.is_datetime64_any_dtype(result["timestamp"])
+
+
+def test_to_datetime_missing_raises(sample_df):
+    with pytest.raises(KeyError):
+        jtransform.to_datetime(sample_df, columns=["no_such_col"])
+
+
+# --- to_object ---
+def test_to_object_basic(unique_test_df):
+    df_cat = jtransform.to_categorical(unique_test_df, columns=["Category"])
+    result = jtransform.to_object(df_cat, columns=["Category"])
+    assert result["Category"].dtype == object
+
+
+def test_to_object_missing_raises(unique_test_df):
+    with pytest.raises(ValueError, match="Columns not found"):
+        jtransform.to_object(unique_test_df, columns=["NoCol"])
+        
 # --- clean_column_names ---
 def test_clean_column_names_basic():
     df = pd.DataFrame(columns=["First Name", "Last Name", "Age"])

--- a/tests/test_transform_module.py
+++ b/tests/test_transform_module.py
@@ -1,0 +1,84 @@
+import pytest
+import pandas as pd
+from jcds import transform as jtransform
+
+
+# --- to_int ---
+def test_to_int_basic(unique_test_df):
+    result = jtransform.to_int(unique_test_df, columns=["Numeric"])
+    assert result["Numeric"].dtype.name == "int8"
+
+
+def test_to_int_missing_column_raises(unique_test_df):
+    with pytest.raises(ValueError, match="Columns not found"):
+        jtransform.to_int(unique_test_df, columns=["no_such_col"])
+
+
+# --- to_float ---
+def test_to_float_basic(unique_test_df):
+    result = jtransform.to_float(unique_test_df, columns=["Numeric"])
+    assert result["Numeric"].dtype.kind == "f"
+
+
+def test_to_float_missing_column_raises(unique_test_df):
+    with pytest.raises(ValueError, match="Columns not found"):
+        jtransform.to_float(unique_test_df, columns=["no_such_col"])
+
+
+# --- to_numeric ---
+def test_to_numeric_basic(unique_test_df):
+    result = jtransform.to_numeric(unique_test_df, columns=["Numeric"])
+    assert pd.api.types.is_numeric_dtype(result["Numeric"])
+
+
+def test_to_numeric_missing_column_raises(unique_test_df):
+    with pytest.raises(KeyError):
+        jtransform.to_numeric(unique_test_df, columns=["no_such_col"])
+
+
+# --- to_str ---
+def test_to_str_basic(unique_test_df):
+    result = jtransform.to_str(unique_test_df, columns=["Numeric"])
+    assert result["Numeric"].dtype == object
+
+
+def test_to_str_missing_column_raises(unique_test_df):
+    with pytest.raises(ValueError, match="Columns not found"):
+        jtransform.to_str(unique_test_df, columns=["no_such_col"])
+
+
+# --- clean_column_names ---
+def test_clean_column_names_basic():
+    df = pd.DataFrame(columns=["First Name", "Last Name", "Age"])
+    result = jtransform.clean_column_names(df)
+    assert list(result.columns) == ["first_name", "last_name", "age"]
+
+
+def test_clean_column_names_collision():
+    df = pd.DataFrame(columns=["First Name", "First  Name", "Age"])
+    result = jtransform.clean_column_names(df)
+    assert list(result.columns) == ["first_name", "first_name_1", "age"]
+
+
+# --- rename_column ---
+def test_rename_column_basic(sample_df):
+    result = jtransform.rename_column(sample_df, "Age", "age")
+    assert "age" in result.columns
+    assert "Age" not in result.columns
+
+
+def test_rename_column_missing_raises(sample_df):
+    with pytest.raises(ValueError, match="not found"):
+        jtransform.rename_column(sample_df, "missing_col", "new_name")
+
+
+# --- delete_columns ---
+def test_delete_columns_basic(sample_df):
+    result = jtransform.delete_columns(sample_df, ["Age", "Income"])
+    assert "Age" not in result.columns
+    assert "Income" not in result.columns
+
+
+def test_delete_columns_missing_raises(sample_df):
+    with pytest.raises(KeyError):
+        jtransform.delete_columns(sample_df, ["NotAColumn"])

--- a/tests/test_univariate.py
+++ b/tests/test_univariate.py
@@ -1,3 +1,4 @@
+import pytest
 from jcds.eda import univariate
 
 
@@ -11,3 +12,12 @@ def test_describe_categorical(sample_df):
 
 def test_plot_categorical_runs_without_error(sample_df):
     univariate.plot_categorical(sample_df["Gender"])  # Just confirm it runs
+    
+
+def test_categorical_barplot_charts(sample_df):
+    """Test that charts.categorical_barplot runs without error."""
+    from jcds import charts
+    try:
+        charts.categorical_barplot(sample_df["Gender"])
+    except Exception as e:
+        pytest.fail(f"charts.categorical_barplot raised an exception: {e}")


### PR DESCRIPTION
## [0.3.0] – 2026-03-18

### Added

- **`jcds.charts` module**
  New visualization module with cleaner API (`jvis`):
  - `missing_data_heatmap()` — heatmap of missing values across the DataFrame
  - `outlier_boxplots()` — boxplots for numeric (non-binary) columns
  - `correlation_heatmap()` — heatmap of feature correlations
  - `categorical_barplot()` — bar chart for categorical variable distributions

- **`jcds.transform` module**
  New transformation module with cleaner API (`jtrf`):
  - `to_int()`, `to_float()`, `to_numeric()`, `to_str()`
  - `to_categorical()`, `to_bool()`, `to_datetime()`, `to_object()`
  - `clean_column_names()`, `rename_column()`, `delete_columns()`

- **`eda` module additions**
  - `show_null_rows()` — returns rows containing at least one null value
  - `show_null_cols()` — returns columns containing at least one null value

### Changed

- **`show_columns` default changed to `True`**
  `data_info()`, `data_cardinality()`, and `data_quality()` now show column lists by default.

- **`jcds.help()` updated**
  Now includes `reports`, `transform`, and `charts` modules in function listing.

- **`clean_column_names()` collision handling**
  Now appends numeric suffix (e.g., `first_name_1`) when two columns clean to the same name.

### Fixed

- **`show_convar()` now excludes datetime columns**
  Previously, datetime columns were incorrectly counted as numerical variables.

- **`show_mixed_type_columns()` now ignores NaN**
  Previously, columns with NaN values were incorrectly flagged as mixed type.

- **`show_mixed_type_columns()` treats `str` and `numpy.str_` as the same type**
  Prevents false positives after `to_str()` conversion.

- **`show_possible_datetime_columns()` FutureWarning suppressed**
  Added `utc=True` to `pd.to_datetime()` call to suppress pandas FutureWarning.

### Deprecated

The following `eda` functions are deprecated and will be removed in v0.4.0.
Use the `jcds.charts` equivalents instead:

- `eda.plot_outlier_boxplots()` → `charts.outlier_boxplots()`
- `eda.plot_correlation_heatmap()` → `charts.correlation_heatmap()`
- `eda.plot_categorical()` → `charts.categorical_barplot()`

The following `eda.transform` functions are deprecated and will be removed in v0.4.0.
Use the `jcds.transform` equivalents instead:

- `eda.convert_to_int()` → `transform.to_int()`
- `eda.convert_to_float()` → `transform.to_float()`
- `eda.convert_to_numeric()` → `transform.to_numeric()`
- `eda.convert_to_categorical()` → `transform.to_categorical()`
- `eda.convert_to_bool()` → `transform.to_bool()`
- `eda.convert_to_datetime()` → `transform.to_datetime()`
- `eda.convert_to_object()` → `transform.to_object()`
- `eda.clean_column_names()` → `transform.clean_column_names()`
- `eda.rename_column()` → `transform.rename_column()`
- `eda.delete_columns()` → `transform.delete_columns()`

### Documentation

- **README updated**
  Added notebook auto-install snippet with `develop`/stable branch switching logic.

### Testing

- **Test suite expanded from 87 to 120 tests**
  Added coverage for all new `charts`, `transform`, and `eda` additions.